### PR TITLE
Fix `-Werror` failure on Alpine/MUSL libc & GCC 10

### DIFF
--- a/software/writeentropy.c
+++ b/software/writeentropy.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>
 #include <linux/random.h>

--- a/software/writeentropy.c
+++ b/software/writeentropy.c
@@ -25,7 +25,7 @@ static uint32_t readNumberFromFile(char *fileName) {
         exit(1);
     }
     uint32_t value = 0u;
-    char c;
+    int32_t c;
     while( (c = getc(file)) != EOF
            && '0' <= c && c <= '9' ) {
         value *= 10;


### PR DESCRIPTION
Two compiler warnings result in a build failure. One is standards pedantry from MUSL libc, the other is a mishandled error value that GCC 10 issues a warning for. See details in PR commit messages.