### PR TITLE
fixes for reproducible builds

### DIFF
--- a/software/Makefile.darwin
+++ b/software/Makefile.darwin
@@ -1,6 +1,6 @@
-GIT_VERSION := $(shell git --no-pager describe --tags --always)
-GIT_COMMIT  := $(shell git rev-parse --verify HEAD)
-GIT_DATE    := $(firstword $(shell git --no-pager show --date=iso-strict --format="%ad" --name-only))
+GIT_VERSION ?= $(shell git --no-pager describe --tags --always)
+GIT_COMMIT  ?= $(shell git rev-parse --verify HEAD)
+GIT_DATE    ?= $(firstword $(shell git --no-pager show --date=iso-strict --format="%ad" --name-only))
 
 PREFIX = $(DESTDIR)/usr/local
 FTDILOC = /usr/local/Cellar/libftdi/1.4/include/libftdi1/

--- a/software/Makefile.freebsd
+++ b/software/Makefile.freebsd
@@ -1,6 +1,6 @@
-GIT_VERSION := $(shell git --no-pager describe --tags --always)
-GIT_COMMIT  := $(shell git rev-parse --verify HEAD)
-GIT_DATE    := $(firstword $(shell git --no-pager show --date=iso-strict --format="%ad" --name-only))
+GIT_VERSION ?= $(shell git --no-pager describe --tags --always)
+GIT_COMMIT  ?= $(shell git rev-parse --verify HEAD)
+GIT_DATE    ?= $(firstword $(shell git --no-pager show --date=iso-strict --format="%ad" --name-only))
 
 PREFIX = $(DESTDIR)/usr/local
 

--- a/software/Makefile.linux
+++ b/software/Makefile.linux
@@ -1,6 +1,6 @@
-GIT_VERSION := $(shell git --no-pager describe --tags --always)
-GIT_COMMIT  := $(shell git rev-parse --verify HEAD)
-GIT_DATE    := $(firstword $(shell git --no-pager show --date=iso-strict --format="%ad" --name-only))
+GIT_VERSION ?= $(shell git --no-pager describe --tags --always)
+GIT_COMMIT  ?= $(shell git rev-parse --verify HEAD)
+GIT_DATE    ?= $(firstword $(shell git --no-pager show --date=iso-strict --format="%ad" --name-only))
 
 PREFIX = $(DESTDIR)/usr/local
 

--- a/software/Makefile.macos
+++ b/software/Makefile.macos
@@ -1,8 +1,8 @@
 SHELL = /bin/bash
 
-GIT_VERSION := $(shell git --no-pager describe --tags --always)
-GIT_COMMIT  := $(shell git rev-parse --verify HEAD)
-GIT_DATE    := $(firstword $(shell git --no-pager show --date=iso-strict --format="%ad" --name-only))
+GIT_VERSION ?= $(shell git --no-pager describe --tags --always)
+GIT_COMMIT  ?= $(shell git rev-parse --verify HEAD)
+GIT_DATE    ?= $(firstword $(shell git --no-pager show --date=iso-strict --format="%ad" --name-only))
 
 PREFIX = $(DESTDIR)/usr/local
 


### PR DESCRIPTION
NixOS sets these variables as static command line overrides. It should also not harm to provide a default and allow overrides from CLI here.