### PR TITLE
linux: add forced CRNG reseed option for newer kernels

### DIFF
--- a/software/infnoise.h
+++ b/software/infnoise.h
@@ -14,6 +14,7 @@ struct opt_struct {
         bool daemon;            // Run as daemon?
         bool debug;             // Print debugging info?
         bool devRandom;         // Feed /dev/random?
+        bool forceReseed;       // Force reseed when feeding /dev/random?
         bool noOutput;          // Supress output?
         bool listDevices;       // List possible USB-devices?
         bool help;              // Show help
@@ -28,6 +29,7 @@ struct opt_struct {
 void inmWriteEntropyStart(uint32_t bufLen, bool debug);
 void inmWriteEntropyEnd();
 void inmWriteEntropyToPool(uint8_t *bytes, uint32_t length, uint32_t entropy);
+void inmForceKernelRngReseed();
 void inmWaitForPoolToHaveRoom(uint32_t feedFreq);
 
 void startDaemon(struct opt_struct *opts);


### PR DESCRIPTION
Recent Linux kernels seldomly fetch entropy from input pool. Add option to force root and child DRNG reseed via RNDRESEEDCRNG ioctl.

Old kernels pre 2018 do not support this option, therefore log if used on unsupported kernel.