### PR TITLE
macos: fix unused param compiler warning/error

### DIFF
--- a/software/infnoise.c
+++ b/software/infnoise.c
@@ -96,6 +96,7 @@ bool outputBytes(uint8_t *bytes, uint32_t length, uint32_t entropy, bool writeDe
         // suppress warning
         (void) entropy;
         (void) feedFrequency;
+        (void) forceKernelReseed;
         return false;
 #endif
 #ifdef LINUX


### PR DESCRIPTION
Running
```
make -f Makefile.macos
```
yields a compiler failure due to no use of `forceKernelReseed`.