### PR TITLE
fixes for kernel module

### DIFF
--- a/software/kernel/README.md
+++ b/software/kernel/README.md
@@ -86,7 +86,7 @@ sudo modprobe -r ftdi_sio
 sudo ftdi_eeprom --read-eeprom --device i:0x0403:0x6015 backup.eeprom
 
 # Flash new configuration
-sudo ftdi_eeprom --flash-eeprom infnoise-eeprom.conf
+sudo ftdi_eeprom --flash-eeprom --device i:0x0403:0x6015 infnoise-eeprom.conf
 
 # Unplug and replug the device
 ```

--- a/software/kernel/infnoise.h
+++ b/software/kernel/infnoise.h
@@ -259,7 +259,7 @@ void infnoise_keccak_init(struct infnoise_keccak *keccak);
 void infnoise_keccak_absorb(struct infnoise_keccak *keccak, const u8 *data,
 			    unsigned int lanes);
 void infnoise_keccak_extract(struct infnoise_keccak *keccak, u8 *data,
-			     unsigned int lanes);
+			     size_t bytes);
 void infnoise_keccak_permutation(struct infnoise_keccak *keccak);
 
 /* Health check functions (infnoise_health.c) */

--- a/software/kernel/infnoise.h
+++ b/software/kernel/infnoise.h
@@ -17,6 +17,7 @@
 #include <linux/mutex.h>
 #include <linux/completion.h>
 #include <linux/workqueue.h>
+#include <linux/kref.h>
 
 /* USB device IDs - Infinite Noise TRNG (pid.codes registered) */
 #define INFNOISE_VENDOR_ID	0x1209	/* pid.codes VID */
@@ -203,6 +204,8 @@ enum infnoise_flags {
 
 /* Main device structure */
 struct infnoise_device {
+	struct kref kref;		/* Lifetime reference count */
+
 	struct usb_device *udev;
 	struct usb_interface *intf;
 

--- a/software/kernel/infnoise.h
+++ b/software/kernel/infnoise.h
@@ -88,7 +88,13 @@
 #define INM_TABLE_SIZE		(1 << INM_PREDICTION_BITS)	/* 16384 entries */
 #define INM_MIN_DATA		80000	/* Minimum bits before data is valid */
 #define INM_MIN_SAMPLE_SIZE	100	/* Minimum samples */
-#define INM_MAX_SEQUENCE	20	/* Max consecutive same bits */
+/*
+ * Max consecutive same-valued bits before declaring a stuck-at fault.
+ * Sized per NIST SP 800-90B repetition-count test: C >= 1 + ceil(-log2(α)/H),
+ * with α = 2^-30 (false-positive rate) and H = 0.88 bits/bit ⇒ C ≈ 36.
+ * 40 leaves margin for the empirical entropy varying slightly below target.
+ */
+#define INM_MAX_SEQUENCE	40
 #define INM_MAX_COUNT		(1 << 14)	/* Max counter value before scaling */
 
 /*

--- a/software/kernel/infnoise.h
+++ b/software/kernel/infnoise.h
@@ -218,6 +218,7 @@ struct infnoise_device {
 	/* USB endpoints */
 	u8 bulk_in_ep;
 	u8 bulk_out_ep;
+	unsigned int bulk_in_mps;	/* bulk-IN wMaxPacketSize */
 
 	/* Buffers */
 	u8 *clock_buf;		/* Clock pattern buffer (512 bytes) */

--- a/software/kernel/infnoise_health.c
+++ b/software/kernel/infnoise_health.c
@@ -111,6 +111,9 @@ void infnoise_health_reset(struct infnoise_health *health)
 	health->total_zeros = 0;
 	health->even_misfires = 0;
 	health->odd_misfires = 0;
+	health->seq_zeros = 0;
+	health->seq_ones = 0;
+	health->ok_to_use = false;
 }
 
 /*

--- a/software/kernel/infnoise_keccak.c
+++ b/software/kernel/infnoise_keccak.c
@@ -15,6 +15,7 @@
 #include <linux/types.h>
 #include <linux/string.h>
 #include <asm/byteorder.h>
+#include <asm/unaligned.h>
 #include "infnoise.h"
 
 /* Pre-computed round constants for Keccak-1600 */
@@ -136,47 +137,32 @@ static void keccak_permutation_on_words(u64 *state)
 	}
 }
 
-/* Convert bytes to words (for big-endian systems) */
-#if defined(__BIG_ENDIAN)
-static void keccak_bytes_to_words(u64 *words, const u8 *bytes)
-{
-	unsigned int i, j;
-
-	for (i = 0; i < KECCAK_LANES; i++) {
-		words[i] = 0;
-		for (j = 0; j < 8; j++)
-			words[i] |= (u64)bytes[i * 8 + j] << (8 * j);
-	}
-}
-
-static void keccak_words_to_bytes(u8 *bytes, const u64 *words)
-{
-	unsigned int i, j;
-
-	for (i = 0; i < KECCAK_LANES; i++)
-		for (j = 0; j < 8; j++)
-			bytes[i * 8 + j] = (words[i] >> (8 * j)) & 0xFF;
-}
-#endif
-
 /**
  * infnoise_keccak_permutation - Apply Keccak-f[1600] permutation
  * @keccak: Keccak state structure
  *
  * Applies the full 24-round Keccak-f[1600] permutation to the state.
+ *
+ * The state is held as a u8 array, so we cannot cast it to (u64 *) and
+ * permute in place: that would violate strict aliasing and require
+ * 8-byte alignment which kzalloc() does not guarantee on all
+ * architectures (ARCH_KMALLOC_MINALIGN may be 4 on some 32-bit ports).
+ * Always go through a properly-aligned local u64 array using the
+ * little-endian unaligned accessors, which compile to plain loads on
+ * LE hosts and to byteswapping loads on BE hosts.
  */
 void infnoise_keccak_permutation(struct infnoise_keccak *keccak)
 {
-#if defined(__BIG_ENDIAN)
-	u64 state_words[KECCAK_LANES];
+	u64 words[KECCAK_LANES];
+	unsigned int i;
 
-	keccak_bytes_to_words(state_words, keccak->state);
-	keccak_permutation_on_words(state_words);
-	keccak_words_to_bytes(keccak->state, state_words);
-#else
-	/* On little-endian, we can work directly on the byte array */
-	keccak_permutation_on_words((u64 *)keccak->state);
-#endif
+	for (i = 0; i < KECCAK_LANES; i++)
+		words[i] = get_unaligned_le64(&keccak->state[i * 8]);
+
+	keccak_permutation_on_words(words);
+
+	for (i = 0; i < KECCAK_LANES; i++)
+		put_unaligned_le64(words[i], &keccak->state[i * 8]);
 }
 
 /**
@@ -217,17 +203,15 @@ void infnoise_keccak_absorb(struct infnoise_keccak *keccak, const u8 *data,
  * infnoise_keccak_extract - Extract data from Keccak sponge
  * @keccak: Keccak state structure
  * @data: Buffer to store extracted data
- * @lanes: Number of 64-bit lanes to extract (bytes / 8)
+ * @bytes: Number of bytes to extract
  *
  * Copies bytes from the state. Does NOT apply permutation;
  * caller should call keccak_permutation() between extracts
  * if extracting more data than the rate allows.
  */
 void infnoise_keccak_extract(struct infnoise_keccak *keccak, u8 *data,
-			     unsigned int lanes)
+			     size_t bytes)
 {
-	unsigned int bytes = lanes * 8;
-
 	if (bytes > KECCAK_STATE_SIZE)
 		bytes = KECCAK_STATE_SIZE;
 

--- a/software/kernel/infnoise_keccak.c
+++ b/software/kernel/infnoise_keccak.c
@@ -15,7 +15,12 @@
 #include <linux/types.h>
 #include <linux/string.h>
 #include <asm/byteorder.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 #include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 #include "infnoise.h"
 
 /* Pre-computed round constants for Keccak-1600 */

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -55,6 +55,7 @@ static void infnoise_warmup_work(struct work_struct *work);
 static int infnoise_read_data(struct infnoise_device *dev, u8 *result,
 			      size_t max_len, bool raw);
 static int infnoise_configure_ftdi(struct infnoise_device *dev);
+static void infnoise_delete(struct kref *kref);
 
 /*
  * FTDI USB control transfer helper
@@ -235,6 +236,16 @@ static int infnoise_try_recovery(struct infnoise_device *dev)
 			return ret;
 		}
 	}
+
+	/*
+	 * The device has been re-initialized, so any accumulated health
+	 * statistics (and any stuck-at fault flag) reflect the pre-recovery
+	 * device state. Reset health so entropy estimation restarts cleanly.
+	 * Caller must hold dev->lock; recovery is invoked from within the
+	 * locked transfer path.
+	 */
+	infnoise_health_reset(&dev->health);
+	clear_bit(INFNOISE_HEALTH_FAIL, &dev->flags);
 
 	dev->recoveries++;
 	dev->consecutive_errors = 0;
@@ -637,7 +648,7 @@ static void infnoise_warmup_work(struct work_struct *work)
 		set_bit(INFNOISE_WARMUP_DONE, &dev->flags);
 	}
 
-	complete(&dev->warmup_done);
+	complete_all(&dev->warmup_done);
 }
 
 /* ============== hwrng interface ============== */
@@ -646,18 +657,17 @@ static int infnoise_hwrng_read(struct hwrng *rng, void *data, size_t max,
 			       bool wait)
 {
 	struct infnoise_device *dev = (struct infnoise_device *)rng->priv;
-	bool raw = infnoise_raw_mode || dev->raw_mode;
+	/*
+	 * The hwrng feed is governed only by the module-wide raw_mode
+	 * parameter. The per-device dev->raw_mode (toggled via ioctl)
+	 * intentionally does NOT change the hwrng path because hwrng.quality
+	 * is pinned at register time and would silently mismatch the data.
+	 */
+	bool raw = READ_ONCE(infnoise_raw_mode);
 	int ret;
 
 	if (!test_bit(INFNOISE_PRESENT, &dev->flags))
 		return -ENODEV;
-
-	/*
-	 * Update hwrng quality based on current raw mode setting.
-	 * Raw output has ~0.88 bits entropy per bit.
-	 * Whitened (Keccak) output is cryptographically uniform (~1.0 bits/bit).
-	 */
-	dev->hwrng.quality = raw ? INFNOISE_QUALITY_RAW : INFNOISE_QUALITY_WHITENED;
 
 	/* Wait for warmup if requested */
 	if (wait && !test_bit(INFNOISE_WARMUP_DONE, &dev->flags)) {
@@ -682,7 +692,12 @@ static int infnoise_hwrng_read(struct hwrng *rng, void *data, size_t max,
 static int infnoise_hwrng_register(struct infnoise_device *dev)
 {
 	int ret;
-	bool raw = infnoise_raw_mode || dev->raw_mode;
+	/*
+	 * Quality is fixed at register time so the hwrng core sees a stable
+	 * value. Runtime changes to the raw_mode module parameter do not
+	 * retroactively alter the credited quality of already-emitted data.
+	 */
+	bool raw = READ_ONCE(infnoise_raw_mode);
 
 	snprintf(dev->hwrng_name, sizeof(dev->hwrng_name),
 		 "infnoise-%s", dev_name(&dev->intf->dev));
@@ -731,6 +746,12 @@ static int infnoise_open(struct inode *inode, struct file *file)
 	if (!test_bit(INFNOISE_PRESENT, &dev->flags))
 		return -ENODEV;
 
+	/*
+	 * Take a reference on the device for the lifetime of this file.
+	 * This prevents disconnect() from freeing dev while we still hold
+	 * a pointer to it in file->private_data.
+	 */
+	kref_get(&dev->kref);
 	file->private_data = dev;
 
 	return 0;
@@ -738,6 +759,11 @@ static int infnoise_open(struct inode *inode, struct file *file)
 
 static int infnoise_release(struct inode *inode, struct file *file)
 {
+	struct infnoise_device *dev = file->private_data;
+
+	if (dev)
+		kref_put(&dev->kref, infnoise_delete);
+
 	return 0;
 }
 
@@ -771,7 +797,8 @@ static ssize_t infnoise_char_read(struct file *file, char __user *buf,
 
 		mutex_lock(&dev->lock);
 		ret = infnoise_read_data(dev, data, chunk,
-					 infnoise_raw_mode || dev->raw_mode);
+					 READ_ONCE(infnoise_raw_mode) ||
+					 READ_ONCE(dev->raw_mode));
 		mutex_unlock(&dev->lock);
 
 		if (ret < 0)
@@ -783,10 +810,13 @@ static ssize_t infnoise_char_read(struct file *file, char __user *buf,
 				break;
 			if (file->f_flags & O_NONBLOCK)
 				return -EAGAIN;
-			/* Yield CPU and back off to avoid busy-wait / soft lockup */
-			msleep(INFNOISE_RETRY_DELAY_MS);
-			if (signal_pending(current))
-				return -ERESTARTSYS;
+			/*
+			 * Yield CPU and back off to avoid busy-wait / soft
+			 * lockup. msleep_interruptible lets a signal break
+			 * the wait without the full RETRY_DELAY_MS latency.
+			 */
+			if (msleep_interruptible(INFNOISE_RETRY_DELAY_MS))
+				return total ? total : -ERESTARTSYS;
 			continue;
 		}
 
@@ -822,7 +852,7 @@ static long infnoise_ioctl(struct file *file, unsigned int cmd,
 	case INFNOISE_SET_RAW:
 		if (copy_from_user(&raw, (void __user *)arg, sizeof(raw)))
 			return -EFAULT;
-		dev->raw_mode = !!raw;
+		WRITE_ONCE(dev->raw_mode, !!raw);
 		return 0;
 
 	case INFNOISE_GET_ENTROPY:
@@ -856,6 +886,34 @@ static struct usb_class_driver infnoise_class = {
 
 /* ============== USB probe/disconnect ============== */
 
+/*
+ * Final teardown of the device structure.
+ *
+ * Invoked via kref_put() once the last reference is dropped — this is the
+ * disconnect path's reference and any per-open-file references (taken in
+ * infnoise_open(), released in infnoise_release()). Disconnect can return
+ * before all userspace fds have closed; the kref ensures dev outlives any
+ * char_read/ioctl that is still in flight or sleeping on warmup_done.
+ *
+ * Safe against partially-initialized state: kfree(NULL), vfree(NULL) and
+ * usb_put_dev(NULL) are all no-ops, so probe error paths can goto err_put
+ * at any point after kref_init().
+ */
+static void infnoise_delete(struct kref *kref)
+{
+	struct infnoise_device *dev = container_of(kref,
+						   struct infnoise_device,
+						   kref);
+
+	infnoise_health_free(&dev->health);
+	kfree(dev->clock_buf);
+	kfree(dev->usb_buf);
+	kfree(dev->read_buf);
+	kfree(dev->out_buf);
+	usb_put_dev(dev->udev);
+	kfree(dev);
+}
+
 static int infnoise_probe(struct usb_interface *intf,
 			  const struct usb_device_id *id)
 {
@@ -886,6 +944,14 @@ static int infnoise_probe(struct usb_interface *intf,
 	if (!dev)
 		return -ENOMEM;
 
+	/*
+	 * Initialize the lifetime reference *first*. From this point on,
+	 * any error must release the device via kref_put(&dev->kref,
+	 * infnoise_delete) so partially-initialized state is torn down
+	 * consistently.
+	 */
+	kref_init(&dev->kref);
+
 	dev->udev = usb_get_dev(udev);
 	dev->intf = intf;
 	dev->bulk_in_ep = bulk_in->bEndpointAddress;
@@ -903,13 +969,13 @@ static int infnoise_probe(struct usb_interface *intf,
 
 	if (!dev->clock_buf || !dev->usb_buf || !dev->read_buf || !dev->out_buf) {
 		ret = -ENOMEM;
-		goto err_buffers;
+		goto err_put;
 	}
 
 	/* Initialize health check */
 	ret = infnoise_health_init(&dev->health);
 	if (ret)
-		goto err_buffers;
+		goto err_put;
 
 	/* Initialize Keccak */
 	infnoise_keccak_init(&dev->keccak);
@@ -920,12 +986,12 @@ static int infnoise_probe(struct usb_interface *intf,
 	/* Configure FTDI */
 	ret = infnoise_configure_ftdi(dev);
 	if (ret)
-		goto err_health;
+		goto err_put;
 
 	/* Test transfer to prime the device */
 	ret = infnoise_test_transfer(dev);
 	if (ret)
-		goto err_health;
+		goto err_put;
 
 	/* Mark device as present */
 	set_bit(INFNOISE_PRESENT, &dev->flags);
@@ -936,7 +1002,9 @@ static int infnoise_probe(struct usb_interface *intf,
 	ret = usb_register_dev(intf, &infnoise_class);
 	if (ret) {
 		dev_err(&intf->dev, "Could not register char device: %d\n", ret);
-		goto err_health;
+		clear_bit(INFNOISE_PRESENT, &dev->flags);
+		usb_set_intfdata(intf, NULL);
+		goto err_put;
 	}
 	dev->minor = intf->minor;
 	dev_info(&intf->dev, "Registered /dev/infnoise%d\n",
@@ -954,15 +1022,8 @@ static int infnoise_probe(struct usb_interface *intf,
 
 	return 0;
 
-err_health:
-	infnoise_health_free(&dev->health);
-err_buffers:
-	kfree(dev->clock_buf);
-	kfree(dev->usb_buf);
-	kfree(dev->read_buf);
-	kfree(dev->out_buf);
-	usb_put_dev(dev->udev);
-	kfree(dev);
+err_put:
+	kref_put(&dev->kref, infnoise_delete);
 	return ret;
 }
 
@@ -975,31 +1036,37 @@ static void infnoise_disconnect(struct usb_interface *intf)
 
 	dev_info(&intf->dev, "Infinite Noise TRNG disconnected\n");
 
-	/* Mark device as absent */
+	/*
+	 * Mark device as absent before waking sleepers so any waiter that
+	 * resumes from warmup_done observes the cleared bit and bails out.
+	 */
 	clear_bit(INFNOISE_PRESENT, &dev->flags);
 
-	/* Complete any waiting warmup */
+	/* Wake any waiters blocked on warmup completion. */
 	complete_all(&dev->warmup_done);
 
-	/* Cancel warmup work */
+	/* Wait for the warmup work to finish (it may hold dev->lock). */
 	cancel_work_sync(&dev->warmup_work);
 
-	/* Unregister hwrng */
+	/*
+	 * hwrng_unregister() blocks until any in-flight ->read() returns,
+	 * so dev is safe to keep accessing through the hwrng path until
+	 * this returns.
+	 */
 	infnoise_hwrng_unregister(dev);
 
-	/* Unregister character device */
+	/*
+	 * usb_deregister_dev() removes the cdev so no new opens succeed,
+	 * but it does NOT wait for already-open file descriptors to close.
+	 * Those fds still reference dev via file->private_data; their
+	 * per-open kref keeps dev alive until each one is released.
+	 */
 	usb_deregister_dev(intf, &infnoise_class);
 
 	usb_set_intfdata(intf, NULL);
 
-	/* Free resources */
-	infnoise_health_free(&dev->health);
-	kfree(dev->clock_buf);
-	kfree(dev->usb_buf);
-	kfree(dev->read_buf);
-	kfree(dev->out_buf);
-	usb_put_dev(dev->udev);
-	kfree(dev);
+	/* Drop the probe-time reference. */
+	kref_put(&dev->kref, infnoise_delete);
 }
 
 static struct usb_driver infnoise_driver = {

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -922,7 +922,8 @@ static int infnoise_probe(struct usb_interface *intf,
 	struct infnoise_device *dev;
 	int ret;
 
-	dev_info(&intf->dev, "Infinite Noise TRNG detected\n");
+	dev_info(&intf->dev, "Infinite Noise TRNG detected (serial: %s)\n",
+		 udev->serial ? udev->serial : "(none)");
 
 	/* Reset USB device to clear any stale state */
 	ret = usb_reset_device(udev);

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -213,28 +213,31 @@ static int infnoise_try_recovery(struct infnoise_device *dev)
 	/* Small delay to let things settle */
 	msleep(INFNOISE_RETRY_DELAY_MS);
 
-	/* Try to reconfigure the FTDI device */
+	/*
+	 * Try to reconfigure the FTDI device. We deliberately do NOT fall
+	 * back to usb_reset_device() here, even though the previous
+	 * "last resort" reset would sometimes recover wedged FTDI state:
+	 *
+	 *   recovery is invoked from infnoise_hwrng_read() / infnoise_char_read(),
+	 *   which the hwrng core calls with its reading_mutex held. usb_reset_device()
+	 *   forces an unbind of this interface, which runs infnoise_disconnect()
+	 *   synchronously in the same task. disconnect() then calls
+	 *   hwrng_unregister(), which waits for the hwrng cleanup completion —
+	 *   a completion that fires only after the in-flight ->read() returns.
+	 *   That in-flight read *is this task*. Self-deadlock; observed as
+	 *   usb_hub_wq blocked on device_del waiting on the dd reader.
+	 *
+	 * If FTDI reconfigure can't bring the device back, the device is
+	 * wedged badly enough that only a physical replug (or autosuspend
+	 * cycle) will help; the read path returns -EIO and the user can
+	 * decide.
+	 */
 	ret = infnoise_configure_ftdi(dev);
 	if (ret < 0) {
-		dev_warn(&dev->intf->dev,
-			 "FTDI reconfiguration failed (%d), trying USB reset\n", ret);
-
-		/* Last resort: reset the USB device */
-		ret = usb_reset_device(dev->udev);
-		if (ret < 0) {
-			dev_err(&dev->intf->dev,
-				"USB reset failed: %d, device may be unusable\n", ret);
-			return ret;
-		}
-
-		/* Reconfigure after reset */
-		msleep(50);
-		ret = infnoise_configure_ftdi(dev);
-		if (ret < 0) {
-			dev_err(&dev->intf->dev,
-				"FTDI configuration after reset failed: %d\n", ret);
-			return ret;
-		}
+		dev_err(&dev->intf->dev,
+			"FTDI reconfiguration failed (%d); replug to recover\n",
+			ret);
+		return ret;
 	}
 
 	/*

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -653,6 +653,32 @@ static void infnoise_warmup_work(struct work_struct *work)
 
 /* ============== hwrng interface ============== */
 
+/*
+ * Drive recovery if HEALTH_FAIL is latched.
+ *
+ * HEALTH_FAIL is set by the extract path on a stuck-at-N detection, which
+ * can be a false positive on a long but legitimate run of identical bits.
+ * The flag would otherwise dead-end the read paths forever, because they
+ * gate on it before ever reaching the transfer/recovery machinery. Calling
+ * infnoise_try_recovery here resets health state and lets the device
+ * self-heal. Returns 0 if the device is usable, negative errno otherwise.
+ */
+static int infnoise_recover_if_health_failed(struct infnoise_device *dev)
+{
+	int ret = 0;
+
+	if (!test_bit(INFNOISE_HEALTH_FAIL, &dev->flags))
+		return 0;
+
+	mutex_lock(&dev->lock);
+	/* Re-check under lock; another caller may have just recovered. */
+	if (test_bit(INFNOISE_HEALTH_FAIL, &dev->flags))
+		ret = infnoise_try_recovery(dev);
+	mutex_unlock(&dev->lock);
+
+	return ret;
+}
+
 static int infnoise_hwrng_read(struct hwrng *rng, void *data, size_t max,
 			       bool wait)
 {
@@ -679,8 +705,9 @@ static int infnoise_hwrng_read(struct hwrng *rng, void *data, size_t max,
 	if (!test_bit(INFNOISE_WARMUP_DONE, &dev->flags))
 		return 0;
 
-	if (test_bit(INFNOISE_HEALTH_FAIL, &dev->flags))
-		return -EIO;
+	ret = infnoise_recover_if_health_failed(dev);
+	if (ret < 0)
+		return ret;
 
 	mutex_lock(&dev->lock);
 	ret = infnoise_read_data(dev, data, max, raw);
@@ -789,8 +816,9 @@ static ssize_t infnoise_char_read(struct file *file, char __user *buf,
 			return ret;
 	}
 
-	if (test_bit(INFNOISE_HEALTH_FAIL, &dev->flags))
-		return -EIO;
+	ret = infnoise_recover_if_health_failed(dev);
+	if (ret < 0)
+		return ret;
 
 	while (total < count) {
 		chunk = min(count - total, sizeof(data));

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -517,7 +517,7 @@ static int infnoise_keccak_squeeze(struct infnoise_device *dev, u8 *result,
 
 	/* Extract at most 128 bytes (16 lanes) for security margin */
 	out_bytes = min_t(size_t, max_len, 128);
-	infnoise_keccak_extract(&dev->keccak, result, (out_bytes + 7) / 8);
+	infnoise_keccak_extract(&dev->keccak, result, out_bytes);
 
 	/* Permute state for next extraction */
 	infnoise_keccak_permutation(&dev->keccak);

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -142,6 +142,41 @@ static int infnoise_configure_ftdi(struct infnoise_device *dev)
 }
 
 /*
+ * Put the FTDI chip back into a quiet default state.
+ *
+ * The chip latches synchronous bit-bang mode across USB bus resets, so
+ * if we leave it enabled the device keeps streaming data on the bulk-IN
+ * endpoint after we're gone. On the next boot the host controller's
+ * port reset can't bring the device back to addr 0 cleanly — observed
+ * as "Device not responding to setup address" / "device not accepting
+ * address N, error -71" until enough probe-time resets eventually win.
+ *
+ * Issuing BITMODE_RESET (mode 0x00) returns the chip to UART mode where
+ * it stays silent until commanded; the trailing SIO_RESET clears any
+ * latched FTDI controller state.
+ *
+ * Best-effort: if the device is already gone (unplug), control transfers
+ * fail with -ENODEV / -ESHUTDOWN; that's expected, not an error.
+ */
+static void infnoise_quiesce_ftdi(struct infnoise_device *dev)
+{
+	int ret;
+
+	ret = ftdi_control(dev, FTDI_SIO_SET_BITMODE,
+			   (FTDI_BITMODE_RESET << 8) | 0x00,
+			   FTDI_INDEX_INTERFACE_A);
+	if (ret < 0 && ret != -ENODEV && ret != -ESHUTDOWN)
+		dev_dbg(&dev->intf->dev,
+			"Could not exit bit-bang mode on teardown: %d\n", ret);
+
+	ret = ftdi_control(dev, FTDI_SIO_RESET, FTDI_SIO_RESET_SIO,
+			   FTDI_INDEX_INTERFACE_A);
+	if (ret < 0 && ret != -ENODEV && ret != -ESHUTDOWN)
+		dev_dbg(&dev->intf->dev,
+			"Could not reset FTDI on teardown: %d\n", ret);
+}
+
+/*
  * Test USB transfer to verify device is working
  * Similar to what libftdi does during initialization
  */
@@ -1160,16 +1195,54 @@ static void infnoise_disconnect(struct usb_interface *intf)
 	 */
 	usb_deregister_dev(intf, &infnoise_class);
 
+	/*
+	 * Now that all in-flight readers are drained and no new ones can
+	 * start, leave the FTDI chip in a quiet state so a subsequent
+	 * rmmod+modprobe (or replug) doesn't trip on a still-streaming
+	 * bit-bang endpoint. On a real unplug the control transfers fail
+	 * harmlessly with -ENODEV.
+	 */
+	infnoise_quiesce_ftdi(dev);
+
 	usb_set_intfdata(intf, NULL);
 
 	/* Drop the probe-time reference. */
 	kref_put(&dev->kref, infnoise_delete);
 }
 
+/*
+ * shutdown() — invoked by the driver core during system reboot/poweroff.
+ * disconnect() is NOT called on shutdown, so without this hook the FTDI
+ * keeps streaming bit-bang data on its bulk-IN endpoint right up until
+ * power is cut. On the next boot, the host controller's port reset can
+ * race against that data flood and fail to assign an address ("device
+ * not accepting address N, error -71"), recovering only after several
+ * retries from probe / the recovery path.
+ */
+static void infnoise_shutdown(struct usb_interface *intf)
+{
+	struct infnoise_device *dev = usb_get_intfdata(intf);
+
+	if (!dev)
+		return;
+
+	/*
+	 * Stop further driver-initiated I/O so we don't race with the
+	 * quiesce control transfers below. PRESENT gates both read paths
+	 * and the recovery machinery.
+	 */
+	clear_bit(INFNOISE_PRESENT, &dev->flags);
+	complete_all(&dev->warmup_done);
+	cancel_work_sync(&dev->warmup_work);
+
+	infnoise_quiesce_ftdi(dev);
+}
+
 static struct usb_driver infnoise_driver = {
 	.name		= DRIVER_NAME,
 	.probe		= infnoise_probe,
 	.disconnect	= infnoise_disconnect,
+	.shutdown	= infnoise_shutdown,
 	.id_table	= infnoise_table,
 	.supports_autosuspend = 0,  /* No suspend - device feeds entropy continuously */
 };

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -456,6 +456,14 @@ static int infnoise_usb_transfer(struct infnoise_device *dev)
 	int retry;
 
 	for (retry = 0; retry < INFNOISE_MAX_RETRIES; retry++) {
+		/*
+		 * Bail immediately if disconnect ran between retries: don't
+		 * burn another 1 s usb_bulk_msg timeout, and don't keep
+		 * hwrng_unregister() waiting on an in-flight ->read().
+		 */
+		if (!test_bit(INFNOISE_PRESENT, &dev->flags))
+			return -ENODEV;
+
 		ret = infnoise_usb_transfer_once(dev);
 
 		if (ret >= 0) {
@@ -667,6 +675,9 @@ static int infnoise_recover_if_health_failed(struct infnoise_device *dev)
 {
 	int ret = 0;
 
+	if (!test_bit(INFNOISE_PRESENT, &dev->flags))
+		return -ENODEV;
+
 	if (!test_bit(INFNOISE_HEALTH_FAIL, &dev->flags))
 		return 0;
 
@@ -701,6 +712,15 @@ static int infnoise_hwrng_read(struct hwrng *rng, void *data, size_t max,
 		if (ret)
 			return ret;
 	}
+
+	/*
+	 * Re-check PRESENT after the wait: disconnect uses complete_all()
+	 * to wake us, so a successful wait does NOT imply the device is
+	 * still alive. Returning -ENODEV here lets hwrng core release any
+	 * waiters on /dev/hwrng instead of looping on a 0-return.
+	 */
+	if (!test_bit(INFNOISE_PRESENT, &dev->flags))
+		return -ENODEV;
 
 	if (!test_bit(INFNOISE_WARMUP_DONE, &dev->flags))
 		return 0;
@@ -806,6 +826,9 @@ static ssize_t infnoise_char_read(struct file *file, char __user *buf,
 	if (!dev)
 		return -ENODEV;
 
+	if (!test_bit(INFNOISE_PRESENT, &dev->flags))
+		return -ENODEV;
+
 	/* Wait for warmup */
 	if (!test_bit(INFNOISE_WARMUP_DONE, &dev->flags)) {
 		if (file->f_flags & O_NONBLOCK)
@@ -815,6 +838,13 @@ static ssize_t infnoise_char_read(struct file *file, char __user *buf,
 		if (ret)
 			return ret;
 	}
+
+	/*
+	 * disconnect() does complete_all(&warmup_done) to wake any waiter,
+	 * so a successful wait does not mean the device is still here.
+	 */
+	if (!test_bit(INFNOISE_PRESENT, &dev->flags))
+		return -ENODEV;
 
 	ret = infnoise_recover_if_health_failed(dev);
 	if (ret < 0)

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -417,13 +417,24 @@ static int infnoise_usb_transfer_once(struct infnoise_device *dev)
 	/*
 	 * Read samples - FTDI returns data in 64-byte packets with 2 status
 	 * bytes per packet. We need to read until we have enough data bytes.
+	 *
+	 * The URB length passed to usb_bulk_msg() must be a multiple of the
+	 * bulk-IN wMaxPacketSize: if a full max-size packet arrives that
+	 * would push the running byte count past the requested length, xHCI
+	 * raises a babble error (-EOVERFLOW). The first request below is
+	 * already aligned (INFNOISE_USB_READ_SIZE == 9*FTDI_PACKET_SIZE),
+	 * but partial completions on a short packet leave total_read
+	 * non-aligned, so each subsequent request is rounded up to mps.
+	 * usb_buf is allocated with one mps of slack so the rounded-up
+	 * request always fits.
 	 */
 	while (total_read < INFNOISE_USB_READ_SIZE) {
 		int remaining = INFNOISE_USB_READ_SIZE - total_read;
+		int request = ALIGN(remaining, dev->bulk_in_mps);
 
 		ret = usb_bulk_msg(dev->udev,
 				   usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep),
-				   dev->usb_buf + total_read, remaining,
+				   dev->usb_buf + total_read, request,
 				   &actual, INFNOISE_USB_TIMEOUT);
 		if (ret < 0) {
 			if (infnoise_debug)
@@ -1053,14 +1064,24 @@ static int infnoise_probe(struct usb_interface *intf,
 	dev->intf = intf;
 	dev->bulk_in_ep = bulk_in->bEndpointAddress;
 	dev->bulk_out_ep = bulk_out->bEndpointAddress;
+	dev->bulk_in_mps = usb_endpoint_maxp(bulk_in);
+	if (!dev->bulk_in_mps)
+		dev->bulk_in_mps = FTDI_PACKET_SIZE;
 
 	mutex_init(&dev->lock);
 	init_completion(&dev->warmup_done);
 	INIT_WORK(&dev->warmup_work, infnoise_warmup_work);
 
-	/* Allocate buffers */
+	/*
+	 * Allocate buffers. usb_buf carries one extra max-packet of slack so
+	 * the read loop can always request a length rounded up to the bulk-IN
+	 * wMaxPacketSize without risking xHCI babble (-EOVERFLOW) when the
+	 * device delivers a full-packet right after a non-aligned partial
+	 * read.
+	 */
 	dev->clock_buf = kmalloc(INFNOISE_BUFLEN, GFP_KERNEL);
-	dev->usb_buf = kmalloc(INFNOISE_USB_READ_SIZE, GFP_KERNEL);
+	dev->usb_buf = kmalloc(INFNOISE_USB_READ_SIZE + dev->bulk_in_mps,
+			       GFP_KERNEL);
 	dev->read_buf = kmalloc(INFNOISE_BUFLEN, GFP_KERNEL);
 	dev->out_buf = kmalloc(INFNOISE_BYTES_OUT, GFP_KERNEL);
 

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -53,7 +53,7 @@ MODULE_DEVICE_TABLE(usb, infnoise_table);
 static struct usb_driver infnoise_driver;
 static void infnoise_warmup_work(struct work_struct *work);
 static int infnoise_read_data(struct infnoise_device *dev, u8 *result,
-			      size_t max_len, bool raw, bool allow_usb_reset);
+			      size_t max_len, bool raw);
 static int infnoise_configure_ftdi(struct infnoise_device *dev);
 static void infnoise_delete(struct kref *kref);
 
@@ -228,17 +228,17 @@ static int infnoise_test_transfer(struct infnoise_device *dev)
  *
  * This function tries to restore communication with the device after
  * consecutive USB errors. It clears endpoint halts and reconfigures
- * the FTDI chip. If that fails and the caller permits it, it attempts
- * a full USB device reset.
+ * the FTDI chip. If that fails it falls back to a full USB device
+ * reset followed by another reconfigure attempt.
  *
- * @allow_usb_reset: if true, fall back to usb_reset_device() when FTDI
- *   reconfiguration fails. Must be false when called from a context that
- *   holds a lock disconnect() will wait on (see comment below).
+ * Safe to call with dev->lock held: pre_reset/post_reset are defined,
+ * so usb_reset_device() does not unbind this interface and therefore
+ * does not invoke infnoise_disconnect() (which would self-deadlock
+ * waiting on cancel_work_sync()/hwrng_unregister()).
  *
  * Returns 0 on successful recovery, negative error code on failure.
  */
-static int infnoise_try_recovery(struct infnoise_device *dev,
-				 bool allow_usb_reset)
+static int infnoise_try_recovery(struct infnoise_device *dev)
 {
 	int ret;
 
@@ -254,29 +254,8 @@ static int infnoise_try_recovery(struct infnoise_device *dev,
 	/* Small delay to let things settle */
 	msleep(INFNOISE_RETRY_DELAY_MS);
 
-	/*
-	 * Try to reconfigure the FTDI device first; if that succeeds we
-	 * avoid the heavier usb_reset_device() fallback below.
-	 *
-	 * usb_reset_device() forces an unbind of this interface, which runs
-	 * infnoise_disconnect() synchronously in the same task. disconnect()
-	 * calls hwrng_unregister(), which waits for the in-flight ->read()
-	 * to return — that in-flight read *is this task* when recovery is
-	 * invoked from infnoise_hwrng_read() / infnoise_char_read() (the
-	 * hwrng core holds its reading_mutex across ->read()). Self-deadlock,
-	 * observed as usb_hub_wq blocked on device_del waiting on the
-	 * reader. Callers from those paths must therefore pass
-	 * allow_usb_reset=false.
-	 */
 	ret = infnoise_configure_ftdi(dev);
 	if (ret < 0) {
-		if (!allow_usb_reset) {
-			dev_err(&dev->intf->dev,
-				"FTDI reconfiguration failed (%d); replug to recover\n",
-				ret);
-			return ret;
-		}
-
 		dev_warn(&dev->intf->dev,
 			 "FTDI reconfiguration failed (%d); attempting USB reset\n",
 			 ret);
@@ -509,8 +488,7 @@ static bool infnoise_is_recoverable_error(int err)
  * errors exceed INFNOISE_RECOVERY_THRESHOLD, attempts device recovery.
  * Returns number of entropy bits, or negative error.
  */
-static int infnoise_usb_transfer(struct infnoise_device *dev,
-				 bool allow_usb_reset)
+static int infnoise_usb_transfer(struct infnoise_device *dev)
 {
 	int ret;
 	int retry;
@@ -546,8 +524,7 @@ static int infnoise_usb_transfer(struct infnoise_device *dev,
 
 		/* Attempt recovery if we've hit the threshold */
 		if (dev->consecutive_errors >= INFNOISE_RECOVERY_THRESHOLD) {
-			int recovery_ret = infnoise_try_recovery(dev,
-								 allow_usb_reset);
+			int recovery_ret = infnoise_try_recovery(dev);
 
 			if (recovery_ret < 0) {
 				dev_err(&dev->intf->dev,
@@ -601,7 +578,7 @@ static int infnoise_keccak_squeeze(struct infnoise_device *dev, u8 *result,
  * Supports multiplier for increased output rate from Keccak sponge.
  */
 static int infnoise_read_data(struct infnoise_device *dev, u8 *result,
-			      size_t max_len, bool raw, bool allow_usb_reset)
+			      size_t max_len, bool raw)
 {
 	int entropy;
 	size_t out_bytes;
@@ -624,7 +601,7 @@ static int infnoise_read_data(struct infnoise_device *dev, u8 *result,
 	}
 
 	/* Perform USB transfer to get new entropy */
-	entropy = infnoise_usb_transfer(dev, allow_usb_reset);
+	entropy = infnoise_usb_transfer(dev);
 	if (entropy < 0)
 		return entropy;
 
@@ -696,12 +673,7 @@ static void infnoise_warmup_work(struct work_struct *work)
 	while (!infnoise_health_ok(&dev->health) &&
 	       rounds < INFNOISE_WARMUP_ROUNDS &&
 	       test_bit(INFNOISE_PRESENT, &dev->flags)) {
-		/*
-		 * Warmup runs in workqueue context, not under the hwrng
-		 * reading_mutex, so a usb_reset_device() fallback in
-		 * recovery is safe here.
-		 */
-		infnoise_read_data(dev, discard, sizeof(discard), true, true);
+		infnoise_read_data(dev, discard, sizeof(discard), true);
 		rounds++;
 	}
 
@@ -749,14 +721,8 @@ static int infnoise_recover_if_health_failed(struct infnoise_device *dev)
 
 	mutex_lock(&dev->lock);
 	/* Re-check under lock; another caller may have just recovered. */
-	if (test_bit(INFNOISE_HEALTH_FAIL, &dev->flags)) {
-		/*
-		 * Both callers (hwrng_read, char_read) reach this with
-		 * locks held that disconnect() will wait on, so the
-		 * usb_reset_device() fallback in recovery must stay off.
-		 */
-		ret = infnoise_try_recovery(dev, false);
-	}
+	if (test_bit(INFNOISE_HEALTH_FAIL, &dev->flags))
+		ret = infnoise_try_recovery(dev);
 	mutex_unlock(&dev->lock);
 
 	return ret;
@@ -802,7 +768,7 @@ static int infnoise_hwrng_read(struct hwrng *rng, void *data, size_t max,
 		return ret;
 
 	mutex_lock(&dev->lock);
-	ret = infnoise_read_data(dev, data, max, raw, false);
+	ret = infnoise_read_data(dev, data, max, raw);
 	mutex_unlock(&dev->lock);
 
 	return ret;
@@ -928,8 +894,7 @@ static ssize_t infnoise_char_read(struct file *file, char __user *buf,
 		mutex_lock(&dev->lock);
 		ret = infnoise_read_data(dev, data, chunk,
 					 READ_ONCE(infnoise_raw_mode) ||
-					 READ_ONCE(dev->raw_mode),
-					 false);
+					 READ_ONCE(dev->raw_mode));
 		mutex_unlock(&dev->lock);
 
 		if (ret < 0)
@@ -1238,11 +1203,40 @@ static void infnoise_shutdown(struct usb_interface *intf)
 	infnoise_quiesce_ftdi(dev);
 }
 
+/*
+ * pre_reset() / post_reset() — declared so usb_reset_device() does NOT
+ * unbind this interface across a bus reset.
+ *
+ * Without these callbacks the USB core forces an unbind+rebind, which
+ * runs infnoise_disconnect() synchronously in the resetting task. That
+ * task is typically the warmup workqueue worker or a thread holding
+ * dev->lock from the recovery path, both of which disconnect() then
+ * tries to wait on (cancel_work_sync(&warmup_work),
+ * hwrng_unregister(), and the implicit dev->lock dependency) →
+ * self-deadlock.
+ *
+ * No quiescing work is needed here: this driver issues only synchronous
+ * usb_bulk_msg / usb_control_msg transfers, all serialized by dev->lock,
+ * which the only reset call site (infnoise_try_recovery) already holds.
+ * Returning 0 tells the USB core to keep us bound across the reset.
+ */
+static int infnoise_pre_reset(struct usb_interface *intf)
+{
+	return 0;
+}
+
+static int infnoise_post_reset(struct usb_interface *intf)
+{
+	return 0;
+}
+
 static struct usb_driver infnoise_driver = {
 	.name		= DRIVER_NAME,
 	.probe		= infnoise_probe,
 	.disconnect	= infnoise_disconnect,
 	.shutdown	= infnoise_shutdown,
+	.pre_reset	= infnoise_pre_reset,
+	.post_reset	= infnoise_post_reset,
 	.id_table	= infnoise_table,
 	.supports_autosuspend = 0,  /* No suspend - device feeds entropy continuously */
 };

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -53,7 +53,7 @@ MODULE_DEVICE_TABLE(usb, infnoise_table);
 static struct usb_driver infnoise_driver;
 static void infnoise_warmup_work(struct work_struct *work);
 static int infnoise_read_data(struct infnoise_device *dev, u8 *result,
-			      size_t max_len, bool raw);
+			      size_t max_len, bool raw, bool allow_usb_reset);
 static int infnoise_configure_ftdi(struct infnoise_device *dev);
 static void infnoise_delete(struct kref *kref);
 
@@ -193,11 +193,17 @@ static int infnoise_test_transfer(struct infnoise_device *dev)
  *
  * This function tries to restore communication with the device after
  * consecutive USB errors. It clears endpoint halts and reconfigures
- * the FTDI chip. If that fails, it attempts a full USB device reset.
+ * the FTDI chip. If that fails and the caller permits it, it attempts
+ * a full USB device reset.
+ *
+ * @allow_usb_reset: if true, fall back to usb_reset_device() when FTDI
+ *   reconfiguration fails. Must be false when called from a context that
+ *   holds a lock disconnect() will wait on (see comment below).
  *
  * Returns 0 on successful recovery, negative error code on failure.
  */
-static int infnoise_try_recovery(struct infnoise_device *dev)
+static int infnoise_try_recovery(struct infnoise_device *dev,
+				 bool allow_usb_reset)
 {
 	int ret;
 
@@ -214,30 +220,45 @@ static int infnoise_try_recovery(struct infnoise_device *dev)
 	msleep(INFNOISE_RETRY_DELAY_MS);
 
 	/*
-	 * Try to reconfigure the FTDI device. We deliberately do NOT fall
-	 * back to usb_reset_device() here, even though the previous
-	 * "last resort" reset would sometimes recover wedged FTDI state:
+	 * Try to reconfigure the FTDI device first; if that succeeds we
+	 * avoid the heavier usb_reset_device() fallback below.
 	 *
-	 *   recovery is invoked from infnoise_hwrng_read() / infnoise_char_read(),
-	 *   which the hwrng core calls with its reading_mutex held. usb_reset_device()
-	 *   forces an unbind of this interface, which runs infnoise_disconnect()
-	 *   synchronously in the same task. disconnect() then calls
-	 *   hwrng_unregister(), which waits for the hwrng cleanup completion —
-	 *   a completion that fires only after the in-flight ->read() returns.
-	 *   That in-flight read *is this task*. Self-deadlock; observed as
-	 *   usb_hub_wq blocked on device_del waiting on the dd reader.
-	 *
-	 * If FTDI reconfigure can't bring the device back, the device is
-	 * wedged badly enough that only a physical replug (or autosuspend
-	 * cycle) will help; the read path returns -EIO and the user can
-	 * decide.
+	 * usb_reset_device() forces an unbind of this interface, which runs
+	 * infnoise_disconnect() synchronously in the same task. disconnect()
+	 * calls hwrng_unregister(), which waits for the in-flight ->read()
+	 * to return — that in-flight read *is this task* when recovery is
+	 * invoked from infnoise_hwrng_read() / infnoise_char_read() (the
+	 * hwrng core holds its reading_mutex across ->read()). Self-deadlock,
+	 * observed as usb_hub_wq blocked on device_del waiting on the
+	 * reader. Callers from those paths must therefore pass
+	 * allow_usb_reset=false.
 	 */
 	ret = infnoise_configure_ftdi(dev);
 	if (ret < 0) {
-		dev_err(&dev->intf->dev,
-			"FTDI reconfiguration failed (%d); replug to recover\n",
-			ret);
-		return ret;
+		if (!allow_usb_reset) {
+			dev_err(&dev->intf->dev,
+				"FTDI reconfiguration failed (%d); replug to recover\n",
+				ret);
+			return ret;
+		}
+
+		dev_warn(&dev->intf->dev,
+			 "FTDI reconfiguration failed (%d); attempting USB reset\n",
+			 ret);
+		ret = usb_reset_device(dev->udev);
+		if (ret < 0) {
+			dev_err(&dev->intf->dev,
+				"USB reset failed (%d); replug to recover\n",
+				ret);
+			return ret;
+		}
+		ret = infnoise_configure_ftdi(dev);
+		if (ret < 0) {
+			dev_err(&dev->intf->dev,
+				"FTDI reconfiguration after reset failed (%d); replug to recover\n",
+				ret);
+			return ret;
+		}
 	}
 
 	/*
@@ -453,7 +474,8 @@ static bool infnoise_is_recoverable_error(int err)
  * errors exceed INFNOISE_RECOVERY_THRESHOLD, attempts device recovery.
  * Returns number of entropy bits, or negative error.
  */
-static int infnoise_usb_transfer(struct infnoise_device *dev)
+static int infnoise_usb_transfer(struct infnoise_device *dev,
+				 bool allow_usb_reset)
 {
 	int ret;
 	int retry;
@@ -489,7 +511,8 @@ static int infnoise_usb_transfer(struct infnoise_device *dev)
 
 		/* Attempt recovery if we've hit the threshold */
 		if (dev->consecutive_errors >= INFNOISE_RECOVERY_THRESHOLD) {
-			int recovery_ret = infnoise_try_recovery(dev);
+			int recovery_ret = infnoise_try_recovery(dev,
+								 allow_usb_reset);
 
 			if (recovery_ret < 0) {
 				dev_err(&dev->intf->dev,
@@ -543,7 +566,7 @@ static int infnoise_keccak_squeeze(struct infnoise_device *dev, u8 *result,
  * Supports multiplier for increased output rate from Keccak sponge.
  */
 static int infnoise_read_data(struct infnoise_device *dev, u8 *result,
-			      size_t max_len, bool raw)
+			      size_t max_len, bool raw, bool allow_usb_reset)
 {
 	int entropy;
 	size_t out_bytes;
@@ -566,7 +589,7 @@ static int infnoise_read_data(struct infnoise_device *dev, u8 *result,
 	}
 
 	/* Perform USB transfer to get new entropy */
-	entropy = infnoise_usb_transfer(dev);
+	entropy = infnoise_usb_transfer(dev, allow_usb_reset);
 	if (entropy < 0)
 		return entropy;
 
@@ -638,7 +661,12 @@ static void infnoise_warmup_work(struct work_struct *work)
 	while (!infnoise_health_ok(&dev->health) &&
 	       rounds < INFNOISE_WARMUP_ROUNDS &&
 	       test_bit(INFNOISE_PRESENT, &dev->flags)) {
-		infnoise_read_data(dev, discard, sizeof(discard), true);
+		/*
+		 * Warmup runs in workqueue context, not under the hwrng
+		 * reading_mutex, so a usb_reset_device() fallback in
+		 * recovery is safe here.
+		 */
+		infnoise_read_data(dev, discard, sizeof(discard), true, true);
 		rounds++;
 	}
 
@@ -686,8 +714,14 @@ static int infnoise_recover_if_health_failed(struct infnoise_device *dev)
 
 	mutex_lock(&dev->lock);
 	/* Re-check under lock; another caller may have just recovered. */
-	if (test_bit(INFNOISE_HEALTH_FAIL, &dev->flags))
-		ret = infnoise_try_recovery(dev);
+	if (test_bit(INFNOISE_HEALTH_FAIL, &dev->flags)) {
+		/*
+		 * Both callers (hwrng_read, char_read) reach this with
+		 * locks held that disconnect() will wait on, so the
+		 * usb_reset_device() fallback in recovery must stay off.
+		 */
+		ret = infnoise_try_recovery(dev, false);
+	}
 	mutex_unlock(&dev->lock);
 
 	return ret;
@@ -733,7 +767,7 @@ static int infnoise_hwrng_read(struct hwrng *rng, void *data, size_t max,
 		return ret;
 
 	mutex_lock(&dev->lock);
-	ret = infnoise_read_data(dev, data, max, raw);
+	ret = infnoise_read_data(dev, data, max, raw, false);
 	mutex_unlock(&dev->lock);
 
 	return ret;
@@ -859,7 +893,8 @@ static ssize_t infnoise_char_read(struct file *file, char __user *buf,
 		mutex_lock(&dev->lock);
 		ret = infnoise_read_data(dev, data, chunk,
 					 READ_ONCE(infnoise_raw_mode) ||
-					 READ_ONCE(dev->raw_mode));
+					 READ_ONCE(dev->raw_mode),
+					 false);
 		mutex_unlock(&dev->lock);
 
 		if (ret < 0)


### PR DESCRIPTION
I tested the kernel module and saw, that it did not recover from health errors, when repeatedly hot-plugging the USB RNG. After some testing and consulting Claude Code, the following seems to work for me now.

Flashing the vendor and product IDs did not succeed without setting the old IDs to match on. I updated the README.md accordingly.